### PR TITLE
Add option to install system packages on sweeps and experiments

### DIFF
--- a/lightning_hpo/commands/experiment/run.py
+++ b/lightning_hpo/commands/experiment/run.py
@@ -25,6 +25,12 @@ class RunExperimentCommand(ClientCommand):
             help="List of requirements separated by a comma or requirements.txt filepath.",
         )
         parser.add_argument(
+            "--packages",
+            nargs="+",
+            default=[],
+            help="List of system packages to be installed via apt install, separated by a comma.",
+        )
+        parser.add_argument(
             "--cloud_compute",
             default="cpu",
             choices=["cpu", "cpu-small", "cpu-medium", "gpu", "gpu-fast", "gpu-fast-multi"],
@@ -93,6 +99,7 @@ class RunExperimentCommand(ClientCommand):
             total_experiments=1,
             parallel_experiments=1,
             requirements=hparams.requirements,
+            packages=hparams.packages,
             script_args=args,
             distributions={},
             algorithm="",

--- a/lightning_hpo/commands/sweep/run.py
+++ b/lightning_hpo/commands/sweep/run.py
@@ -60,6 +60,7 @@ class SweepConfig(SQLModel, table=True):
     parallel_experiments: int
     total_experiments_done: int = 0
     requirements: List[str] = Field(..., sa_column=Column(pydantic_column_type(List[str])))
+    packages: List[str] = Field(..., sa_column=Column(pydantic_column_type(List[str])))
     script_args: List[str] = Field(..., sa_column=Column(pydantic_column_type(List[str])))
     algorithm: str
     distributions: Dict[str, Distributions] = Field(
@@ -319,6 +320,12 @@ class RunSweepCommand(ClientCommand):
             help="List of requirements separated by a comma or requirements.txt filepath.",
         )
         parser.add_argument(
+            "--packages",
+            nargs="+",
+            default=[],
+            help="List of system packages to be installed via apt install, separated by a comma.",
+        )
+        parser.add_argument(
             "--cloud_compute",
             default="cpu",
             choices=["cpu", "cpu-small", "cpu-medium", "gpu", "gpu-fast", "gpu-fast-multi"],
@@ -420,6 +427,7 @@ class RunSweepCommand(ClientCommand):
             total_experiments=int(total_experiments),
             parallel_experiments=hparams.parallel_experiments if isinstance(hparams.parallel_experiments, int) else 1,
             requirements=hparams.requirements,
+            packages=hparams.packages,
             script_args=script_args,
             distributions=distributions,
             algorithm=hparams.algorithm,

--- a/tests/commands/experiment/test_run.py
+++ b/tests/commands/experiment/test_run.py
@@ -46,6 +46,7 @@ def test_experiment_run_parsing_no_arguments(monkeypatch):
             parallel_experiments=1,
             total_experiments_done=0,
             requirements=[],
+            packages=[],
             script_args=[],
             algorithm="",
             distributions={},
@@ -111,6 +112,7 @@ def test_experiment_run_parsing_arguments(monkeypatch):
             parallel_experiments=1,
             total_experiments_done=0,
             requirements=["'jsonargparse[signatures]'"],
+            packages=[],
             script_args=["--model.lr=0.1"],
             algorithm="",
             distributions={},
@@ -157,6 +159,29 @@ def test_experiment_run_multiple_requirements(monkeypatch):
     command.run()
 
 
+def test_experiment_run_multiple_packages(monkeypatch):
+
+    monkeypatch.setattr(run, "CustomLocalSourceCodeDir", MagicMock())
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "",
+            __file__,
+            "--packages",
+            "redis",
+            "ffmpeg",
+        ],
+    )
+
+    def check(config: SweepConfig):
+        assert config.requirements == ["redis", "ffmpeg"]
+
+    command = _create_client_command_mock(run.RunExperimentCommand, None, MagicMock(), check)
+    command.run()
+
+
 def test_experiment_run_parsing_requirements(monkeypatch):
 
     monkeypatch.setattr(run, "CustomLocalSourceCodeDir", MagicMock())
@@ -186,6 +211,7 @@ def test_experiment_run_parsing_requirements(monkeypatch):
             parallel_experiments=1,
             total_experiments_done=0,
             requirements=["pytorch_lightning", "optuna", "deepspeed"],
+            packages=[],
             script_args=[],
             algorithm="",
             distributions={},

--- a/tests/commands/sweep/sweep_1.json
+++ b/tests/commands/sweep/sweep_1.json
@@ -1,6 +1,7 @@
 [
     {
       "requirements": "[]",
+      "packages": "[]",
       "script_args": "[]",
       "distributions": {"model.lr": {"distribution": "uniform", "params": {"low": 0.001, "high": 0.1}}},
       "experiments": {"0": {"name": "a", "best_model_score": 0.125, "monitor": "val_acc", "best_model_path": null, "status": "succeeded", "params": {"model.lr": 0.04490742315966646}, "exception": null, "start_time": null, "end_time": null, "total_parameters": null}, "1": {"name": "b", "best_model_score": 0.125, "monitor": "val_acc", "best_model_path": null, "status": "succeeded", "params": {"model.lr": 0.0860064559763192}, "exception": null, "start_time": null, "end_time": null, "total_parameters": null}, "2": {"name": "c", "best_model_score": 0.125, "monitor": "val_acc", "best_model_path": null, "status": "succeeded", "params": {"model.lr": 0.08511019485430553}, "exception": null, "start_time": null, "end_time": null, "total_parameters": null}},

--- a/tests/controllers/test_sweep.py
+++ b/tests/controllers/test_sweep.py
@@ -18,6 +18,7 @@ def test_sweep_controller(monkeypatch):
         script_path=__file__,
         total_experiments=5,
         requirements=[],
+        packages=[],
         parallel_experiments=1,
         logger="tensorboard",
         distributions={"best_model_score": Uniform(1, 10)},


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning-hpo/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?

It's not uncommon to need specific system packages to be installed for experiments to run. This PR adds the `--packages` CLI option to `run sweep` and `run experiment`, which translate in calls to `apt install <package>` in `BuildConfig`.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
